### PR TITLE
feat: implement workspace for user_preference

### DIFF
--- a/almonds/app/stores/user-preference.ts
+++ b/almonds/app/stores/user-preference.ts
@@ -1,11 +1,13 @@
 import { defineStore } from "pinia";
 import { invoke } from "@tauri-apps/api/core";
+import { getWorkspaceMeta } from "~/composables/getWorkspaceMeta";
 
 export interface UserPreference {
   identifier: string;
   firstName: string;
   lastName: string;
   email: string;
+  workspaceIdentifier: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -41,6 +43,9 @@ export const useUserPreferenceStore = defineStore("user_preference_store", {
       try {
         this.preference = await invoke<UserPreference | null>(
           "get_user_preference",
+          {
+            meta: await getWorkspaceMeta(),
+          },
         );
       } finally {
         this.loading = false;
@@ -52,6 +57,7 @@ export const useUserPreferenceStore = defineStore("user_preference_store", {
     ): Promise<UserPreference> {
       const created = await invoke<UserPreference>("create_user_preference", {
         preference: payload,
+        meta: await getWorkspaceMeta(),
       });
       this.preference = created;
       return created;
@@ -63,6 +69,7 @@ export const useUserPreferenceStore = defineStore("user_preference_store", {
       const updated = await invoke<UserPreference>("update_user_preference", {
         identifier: this.preference!.identifier,
         preference: payload,
+        meta: await getWorkspaceMeta(),
       });
       this.preference = updated;
       return updated;

--- a/almonds/src-tauri/src/commands/user_preference.rs
+++ b/almonds/src-tauri/src/commands/user_preference.rs
@@ -16,10 +16,11 @@ use crate::{
 #[tauri::command]
 pub async fn get_user_preference(
     state: State<'_, AppState>,
+    meta: Option<RequestMeta>,
 ) -> Result<Option<user_preference::Model>, AppError> {
     state
         .user_preference_repository
-        .get()
+        .get(&meta)
         .await
         .map_err(Into::into)
 }
@@ -28,10 +29,11 @@ pub async fn get_user_preference(
 pub async fn create_user_preference(
     state: State<'_, AppState>,
     preference: CreateUserPreference,
+    meta: Option<RequestMeta>,
 ) -> Result<user_preference::Model, AppError> {
     let created = state
         .user_preference_repository
-        .create(&preference.into())
+        .create(&preference.into(), &meta)
         .await?;
     Ok(created)
 }
@@ -41,10 +43,11 @@ pub async fn update_user_preference(
     state: State<'_, AppState>,
     identifier: Uuid,
     preference: UpdateUserPreference,
+    meta: Option<RequestMeta>,
 ) -> Result<user_preference::Model, AppError> {
     let updated = state
         .user_preference_repository
-        .update(&identifier, &preference.into())
+        .update(&identifier, &preference.into(), &meta)
         .await?;
     Ok(updated)
 }

--- a/kernel/migration/src/lib.rs
+++ b/kernel/migration/src/lib.rs
@@ -23,6 +23,7 @@ mod m20260226_063044_make_notes_categories_optional;
 mod m20260226_064924_drop_notes_new;
 mod m20260304_080239_create_default_workspace;
 mod m20260314_150343_create_trigger_for_bookmarks;
+mod m20260327_000000_add_workspace_id_to_user_preference;
 
 pub use sea_orm_migration::prelude::*;
 
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260226_064924_drop_notes_new::Migration),
             Box::new(m20260304_080239_create_default_workspace::Migration),
             Box::new(m20260314_150343_create_trigger_for_bookmarks::Migration),
+            Box::new(m20260327_000000_add_workspace_id_to_user_preference::Migration),
         ]
     }
 }

--- a/kernel/migration/src/m20260221_065938_create_user_preference_table.rs
+++ b/kernel/migration/src/m20260221_065938_create_user_preference_table.rs
@@ -30,7 +30,7 @@ impl MigrationTrait for Migration {
 }
 
 #[derive(DeriveIden)]
-enum UserPreference {
+pub enum UserPreference {
     Table,
     Identifier,
     FirstName,

--- a/kernel/migration/src/m20260327_000000_add_workspace_id_to_user_preference.rs
+++ b/kernel/migration/src/m20260327_000000_add_workspace_id_to_user_preference.rs
@@ -1,0 +1,95 @@
+use sea_orm_migration::{prelude::*, schema::*, sea_orm::DbBackend};
+
+use crate::{
+    m20260221_065938_create_user_preference_table::UserPreference,
+    m20260224_214545_create_workspaces::Workspaces,
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db_backend = manager.get_database_backend();
+        let db_connection = manager.get_connection();
+        if db_backend == DbBackend::Sqlite {
+            manager
+                .create_table(
+                    Table::create()
+                        .table("user_preference_new")
+                        .if_not_exists()
+                        .col(pk_uuid("identifier"))
+                        .col(string("first_name"))
+                        .col(string("last_name"))
+                        .col(string_uniq("email"))
+                        .col(ColumnDef::new("workspace_identifier").uuid())
+                        .foreign_key(
+                            ForeignKey::create()
+                                .name("fk_user_preference_workspace_identifier")
+                                .from(UserPreference::Table, "workspace_identifier")
+                                .to(Workspaces::Table, "identifier")
+                                .on_delete(ForeignKeyAction::Cascade),
+                        )
+                        .col(timestamp_with_time_zone(UserPreference::CreatedAt))
+                        .col(timestamp_with_time_zone(UserPreference::UpdatedAt))
+                        .to_owned(),
+                )
+                .await?;
+
+            db_connection
+                .execute_unprepared(
+                    r#"
+                    INSERT INTO "user_preference_new" ("identifier", "first_name", "last_name", "email", "created_at", "updated_at")
+                    SELECT "identifier", "first_name", "last_name", "email", "created_at", "updated_at" FROM "user_preference";
+
+                    DROP TABLE "user_preference";
+                    ALTER TABLE "user_preference_new" RENAME TO "user_preference";
+                    "#,
+                )
+                .await?;
+
+            return Ok(());
+        }
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserPreference::Table)
+                    .add_column(ColumnDef::new("workspace_identifier").uuid())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("fk_user_preference_workspace_identifier")
+                    .from(UserPreference::Table, "workspace_identifier")
+                    .to(Workspaces::Table, "identifier")
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_foreign_key(
+                ForeignKey::drop()
+                    .name("fk_user_preference_workspace_identifier")
+                    .table(UserPreference::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(UserPreference::Table)
+                    .drop_column("workspace_identifier")
+                    .to_owned(),
+            )
+            .await
+    }
+}

--- a/kernel/src/adapters/user_preference.rs
+++ b/kernel/src/adapters/user_preference.rs
@@ -20,6 +20,7 @@ impl Into<entities::user_preference::ActiveModel> for CreateUserPreference {
             first_name: Set(self.first_name),
             last_name: Set(self.last_name),
             email: Set(self.email),
+            workspace_identifier: Set(None),
             created_at: Set(Utc::now().fixed_offset()),
             updated_at: Set(Utc::now().fixed_offset()),
         }

--- a/kernel/src/entities/user_preference.rs
+++ b/kernel/src/entities/user_preference.rs
@@ -13,11 +13,27 @@ pub struct Model {
     pub last_name: String,
     #[sea_orm(unique)]
     pub email: String,
+    pub workspace_identifier: Option<Uuid>,
     pub created_at: DateTimeWithTimeZone,
     pub updated_at: DateTimeWithTimeZone,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
-pub enum Relation {}
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::workspaces::Entity",
+        from = "Column::WorkspaceIdentifier",
+        to = "super::workspaces::Column::Identifier",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Workspaces,
+}
+
+impl Related<super::workspaces::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Workspaces.def()
+    }
+}
 
 impl ActiveModelBehavior for ActiveModel {}

--- a/kernel/src/repositories/user_preference.rs
+++ b/kernel/src/repositories/user_preference.rs
@@ -14,9 +14,10 @@ use crate::repositories::{
     workspace_manager::{DuplicateRecord, RecordExistInWorkspace, TransferRecord},
 };
 use crate::{
-    adapters::user_preference::{CreateUserPreference, UpdateUserPreference},
+    adapters::{meta::RequestMeta, user_preference::{CreateUserPreference, UpdateUserPreference}},
     entities::user_preference,
     error::KernelError,
+    utils::extract_req_meta,
 };
 
 pub struct UserPreferenceRepository {
@@ -31,14 +32,19 @@ pub trait UserPreferenceRepositoryExt {
     async fn create(
         &self,
         payload: &CreateUserPreference,
+        meta: &Option<RequestMeta>,
     ) -> Result<user_preference::Model, KernelError>;
 
-    async fn get(&self) -> Result<Option<user_preference::Model>, KernelError>;
+    async fn get(
+        &self,
+        meta: &Option<RequestMeta>,
+    ) -> Result<Option<user_preference::Model>, KernelError>;
 
     async fn update(
         &self,
         identifier: &Uuid,
         payload: &UpdateUserPreference,
+        meta: &Option<RequestMeta>,
     ) -> Result<user_preference::Model, KernelError>;
 }
 
@@ -54,16 +60,32 @@ impl UserPreferenceRepositoryExt for UserPreferenceRepository {
     async fn create(
         &self,
         payload: &CreateUserPreference,
+        meta: &Option<RequestMeta>,
     ) -> Result<user_preference::Model, KernelError> {
-        let active_model: user_preference::ActiveModel = payload.to_owned().into();
+        let mut active_model: user_preference::ActiveModel = payload.to_owned().into();
+
+        if let Some(meta) = meta {
+            active_model.workspace_identifier = Set(Some(meta.workspace_identifier));
+        } else {
+            return Err(KernelError::DbOperationError(
+                "workspace identifier is required".into(),
+            ));
+        };
+
         active_model
             .insert(self.conn.as_ref())
             .await
             .map_err(|err| KernelError::DbOperationError(err.to_string()))
     }
 
-    async fn get(&self) -> Result<Option<user_preference::Model>, KernelError> {
+    async fn get(
+        &self,
+        meta: &Option<RequestMeta>,
+    ) -> Result<Option<user_preference::Model>, KernelError> {
+        let meta = extract_req_meta(meta)?;
+
         user_preference::Entity::find()
+            .filter(user_preference::Column::WorkspaceIdentifier.eq(meta.workspace_identifier))
             .one(self.conn.as_ref())
             .await
             .map_err(|err| KernelError::DbOperationError(err.to_string()))
@@ -73,9 +95,13 @@ impl UserPreferenceRepositoryExt for UserPreferenceRepository {
         &self,
         identifier: &Uuid,
         payload: &UpdateUserPreference,
+        meta: &Option<RequestMeta>,
     ) -> Result<user_preference::Model, KernelError> {
+        let meta = extract_req_meta(meta)?;
+
         let model = user_preference::Entity::find()
             .filter(user_preference::Column::Identifier.eq(*identifier))
+            .filter(user_preference::Column::WorkspaceIdentifier.eq(meta.workspace_identifier))
             .one(self.conn.as_ref())
             .await
             .map_err(|err| KernelError::DbOperationError(err.to_string()))?
@@ -102,8 +128,8 @@ impl UserPreferenceRepositoryExt for UserPreferenceRepository {
             .map_err(|err| KernelError::DbOperationError(err.to_string()))
     }
 }
-#[async_trait::async_trait]
 
+#[async_trait::async_trait]
 impl TransferRecord for UserPreferenceRepository {
     async fn transfer_record(
         &self,
@@ -152,7 +178,7 @@ impl TransferRecord for UserPreferenceRepository {
         let mut active_model = record.into_active_model();
 
         active_model.updated_at = Set(Utc::now().fixed_offset());
-        // active_model.workspace_identifier = Set(Some(*target_workspace_identifier));
+        active_model.workspace_identifier = Set(Some(*target_workspace_identifier));
 
         active_model
             .update(self.conn.as_ref())
@@ -162,17 +188,17 @@ impl TransferRecord for UserPreferenceRepository {
         Ok(())
     }
 }
-#[async_trait::async_trait]
 
+#[async_trait::async_trait]
 impl RecordExistInWorkspace for UserPreferenceRepository {
     async fn record_exists_in_workspace(
         &self,
         record_identifier: &Uuid,
-        _workspace_identifier: &Uuid,
+        workspace_identifier: &Uuid,
     ) -> Result<bool, KernelError> {
         let record = user_preference::Entity::find()
             .filter(user_preference::Column::Identifier.eq(*record_identifier))
-            // .filter(user_preference::Column::WorkspaceIdentifier.eq(*workspace_identifier))
+            .filter(user_preference::Column::WorkspaceIdentifier.eq(*workspace_identifier))
             .one(self.conn.as_ref())
             .await
             .map_err(|err| KernelError::DbOperationError(err.to_string()))?;
@@ -180,8 +206,8 @@ impl RecordExistInWorkspace for UserPreferenceRepository {
         Ok(record.is_some())
     }
 }
-#[async_trait::async_trait]
 
+#[async_trait::async_trait]
 impl DuplicateRecord for UserPreferenceRepository {
     async fn duplicate_record(
         &self,
@@ -213,7 +239,7 @@ impl DuplicateRecord for UserPreferenceRepository {
 
         let Some(record) = user_preference::Entity::find()
             .filter(user_preference::Column::Identifier.eq(*record_identifier))
-            // .filter(user_preference::Column::WorkspaceIdentifier.eq(*previous_workspace_identifier))
+            .filter(user_preference::Column::WorkspaceIdentifier.eq(*previous_workspace_identifier))
             .one(self.conn.as_ref())
             .await
             .map_err(|err| KernelError::DbOperationError(err.to_string()))?
@@ -224,7 +250,7 @@ impl DuplicateRecord for UserPreferenceRepository {
         let mut new_record = record.into_active_model();
 
         new_record.identifier = Set(Uuid::new_v4());
-        // new_record.workspace_identifier = Set(Some(*target_workspace_identifier));//TODO: use workspace in user_preference table
+        new_record.workspace_identifier = Set(Some(*target_workspace_identifier));
         new_record.created_at = Set(Utc::now().fixed_offset());
         new_record.updated_at = Set(Utc::now().fixed_offset());
 


### PR DESCRIPTION
Closes #116.    
                                                                                
  - Adds backward-compatible migration to include `workspace_identifier` in     
  `user_preference` (SQLite + Postgres)
  - Updates SeaORM entity with the new column and workspace relation            
  - Adds `RequestMeta` workspace scoping to repository `get`/`create`/`update`  
  methods                                                                       
  - Enables previously commented-out workspace logic in `TransferRecord`,       
  `DuplicateRecord`, `RecordExistInWorkspace`                                   
  - Threads `meta: Option<RequestMeta>` through all Tauri commands
  - Frontend store now passes `getWorkspaceMeta()` on every invoke call 